### PR TITLE
fix: update upload-artifact from v3 to v4 to resolve deprecated action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       if: always()
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: accessibility-test-results


### PR DESCRIPTION
## 🔧 Fix Workflow Deprecated Action

### 🚨 Problema Identificado
O workflow  estava a usar uma versão deprecated do , causando falha automática nos PRs.

### ✅ Solução Implementada
- **Atualizado**:  → 
- **Compatibilidade**: Mantém todas as funcionalidades existentes
- **Estabilidade**: Resolve o erro de deprecação

### 📋 Alteração Realizada


### 🎯 Impacto
- ✅ **Resolve erro** de action deprecated
- ✅ **Mantém funcionalidade** de upload de artifacts
- ✅ **Permite PRs** funcionarem corretamente
- ✅ **Compatibilidade** com GitHub Actions atual

### 🔍 Verificação
- [x] Apenas 1 commit com a alteração
- [x] Conventional commit format
- [x] Workflow atualizado corretamente
- [x] Branch criado a partir de development