### PR TITLE
fix: add @typescript-eslint plugin to eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
   extends: [
     'eslint:recommended',
     '@typescript-eslint/recommended',


### PR DESCRIPTION
Fix ESLint configuration by adding the missing @typescript-eslint plugin declaration.