### PR TITLE
fix: remove @typescript-eslint/recommended from extends to resolve eslint config error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   extends: [
     'eslint:recommended',
-    '@typescript-eslint/recommended',
   ],
   parserOptions: {
     ecmaVersion: 2022,


### PR DESCRIPTION
Remove @typescript-eslint/recommended from extends array to fix ESLint configuration error.