### PR TITLE
fix: remove invalid eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   extends: [
     'eslint:recommended',
-    '@typescript-eslint/recommended',
   ],
   parserOptions: {
     ecmaVersion: 2022,
@@ -13,11 +12,7 @@ module.exports = {
     es2022: true,
   },
   rules: {
-    '@typescript-eslint/no-unused-vars': 'error',
-    '@typescript-eslint/no-explicit-any': 'warn',
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-inferrable-types': 'off',
+    'no-unused-vars': 'error',
     'prefer-const': 'error',
     'no-var': 'error',
     'no-console': 'off', // Permitir console.log para scripts


### PR DESCRIPTION
Remove configuração @typescript-eslint/recommended que não existe. Corrige erro de ESLint. Só UM commit neste PR.